### PR TITLE
Configure Dependabot to group minor and patch updates

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -6,9 +6,19 @@ updates:
       interval: "weekly"
     reviewers:
       - dmingn
+    groups:
+      minor-patch:
+        update-types:
+          - "minor"
+          - "patch"
   - package-ecosystem: "pip"
     directory: "/"
     schedule:
       interval: "weekly"
     reviewers:
       - dmingn
+    groups:
+      minor-patch:
+        update-types:
+          - "minor"
+          - "patch"


### PR DESCRIPTION
This change updates the Dependabot configuration to group minor and patch version updates for both GitHub Actions and Pip packages. This will help reduce the number of individual pull requests generated by Dependabot.